### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Build the Docker image
       run: docker build -t docker.pkg.github.com/unafraid/exampletelegrambot/bot .
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: docker.pkg.github.com/unafraid/exampletelegrambot/bot
         registry: "docker.pkg.github.com"


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore